### PR TITLE
Fix typo in  rehype-katex readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,5 +18,5 @@ jobs:
     strategy:
       matrix:
         node:
-          - lts/erbium
+          - lts/fermium
           - node

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prettier": "^2.0.0",
     "rehype-parse": "^8.0.0",
     "rehype-stringify": "^9.0.0",
-    "remark-cli": "^10.0.0",
+    "remark-cli": "^11.0.0",
     "remark-html": "^15.0.0",
     "remark-parse": "^10.0.0",
     "remark-preset-wooorm": "^9.0.0",
@@ -42,7 +42,7 @@
     "unified": "^10.0.0",
     "unist-builder": "^3.0.0",
     "unist-util-remove-position": "^4.0.0",
-    "xo": "^0.48.0"
+    "xo": "^0.51.0"
   },
   "scripts": {
     "build": "npm run build --workspaces",

--- a/packages/rehype-katex/readme.md
+++ b/packages/rehype-katex/readme.md
@@ -196,7 +196,7 @@ schema, and run `rehype-katex` afterwards.
 Like so:
 
 ```js
-import rehypeSanitize, {defaultSchema} from 'rehype-stringify'
+import rehypeSanitize, {defaultSchema} from 'rehype-sanitize'
 
 const mathSanitizeSchema = {
   ...defaultSchema,

--- a/packages/rehype-katex/test.js
+++ b/packages/rehype-katex/test.js
@@ -149,7 +149,7 @@ test('rehype-katex', (t) => {
       .processSync(
         '<p>Lorem</p>\n<p><span class="math-inline">\\alpa</span></p>'
       )
-      .messages.map((d) => String(d)),
+      .messages.map(String),
     [
       '2:4-2:42: KaTeX parse error: Undefined control sequence: \\alpa at position 1: \\̲a̲l̲p̲a̲'
     ],

--- a/packages/rehype-mathjax/test/fixture/equation-numbering-1-chtml.html
+++ b/packages/rehype-mathjax/test/fixture/equation-numbering-1-chtml.html
@@ -139,6 +139,7 @@ mjx-math {
   font-size: 100%;
   font-size-adjust: none;
   letter-spacing: normal;
+  border-collapse: collapse;
   word-wrap: normal;
   word-spacing: normal;
   white-space: nowrap;

--- a/packages/rehype-mathjax/test/fixture/small-chtml.html
+++ b/packages/rehype-mathjax/test/fixture/small-chtml.html
@@ -138,6 +138,7 @@ mjx-math {
   font-size: 100%;
   font-size-adjust: none;
   letter-spacing: normal;
+  border-collapse: collapse;
   word-wrap: normal;
   word-spacing: normal;
   white-space: nowrap;

--- a/packages/remark-html-katex/test.js
+++ b/packages/remark-html-katex/test.js
@@ -98,7 +98,7 @@ test('remark-html-katex', (t) => {
       .use(remarkHtmlKatex)
       .use(remarkHtml, {sanitize: false})
       .processSync('Lorem\n$\\alpa$')
-      .messages.map((d) => String(d)),
+      .messages.map(String),
     [
       '2:1-2:8: KaTeX parse error: Undefined control sequence: \\alpa at position 1: \\̲a̲l̲p̲a̲'
     ],


### PR DESCRIPTION
```diff
- import rehypeSanitize, {defaultSchema} from 'rehype-stringify'
+ import rehypeSanitize, {defaultSchema} from 'rehype-sanitize'
```